### PR TITLE
Do not rely on short path for miniconda installation dir (CSDS-3114)

### DIFF
--- a/create_offline_installer.py
+++ b/create_offline_installer.py
@@ -367,14 +367,14 @@ class MinicondaOfflineInstaller:
             print(f'  - {p}')
 
     windows_install_script = """@echo off
-if x%~s1==x (
+if "%~1"=="" (
   echo "install target_dir [ccdc_packages_and_package_name_pairs...]"
   goto end
 )
 setlocal
 set installer_dir=%~dps0
 start /wait "" "%installer_dir%{{ installer_exe }}" /AddToPath=0 /S /D=%~s1
-call %~s1\\Scripts\\activate
+call "%~1\\Scripts\\activate"
 echo "CCDC Miniconda installer: updating conda"
 call conda update -y --channel "%installer_dir%conda_offline_channel" --offline --override-channels conda
 echo "CCDC Miniconda installer: updating all packages"


### PR DESCRIPTION
We have a user who reported:

Installing CSD Python API
Executing D:\Program Files\CCDC/Python_API_2021/install.bat "D:\Program Files\CCDC/Python_API_2021/miniconda" ccdc csd-python-api ccdc_knime csd-python-api-knime
Script exit code: 255

Script output:

Script stderr:
 Files\CCDC\Python_API_2021\miniconda==x was unexpected at this time.

Error running D:\Program Files\CCDC/Python_API_2021/install.bat "D:\Program Files\CCDC/Python_API_2021/miniconda" ccdc csd-python-api ccdc_knime csd-python-api-knime: Files\CCDC\Python_API_2021\miniconda==x was unexpected at this time.