### PR TITLE
Create also a minimal installer (WCSD-3060)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Getting Started
 
 - Clone this repository locally
-- run git submodule update to fetch the repodata-hotfixes repository contents
+- run *git submodule init* and *git submodule update* to fetch the repodata-hotfixes repository contents
 - Create a python3 virtualenv
 - pip install -r requirements.txt
 - run with python create_offline_installer.py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,10 +41,10 @@ steps:
   displayName: 'Create Offline installer'
 
 - task: ArchiveFiles@2
-  displayName: 'Archive minimal miniconda archive'
+  displayName: 'Archive webcsd-csp miniconda archive'
   inputs:
-    rootFolderOrFile: '$(System.DefaultWorkingDirectory)/output/minimal-miniconda3-$(miniconda_installer_version)-$(Build.BuildId)-$(buildosname)'
-    archiveFile: '$(Build.ArtifactStagingDirectory)/minimal-miniconda3-$(miniconda_installer_version)-$(Build.BuildId)-$(buildosname).$(outputArchiveExtension)'
+    rootFolderOrFile: '$(System.DefaultWorkingDirectory)/output/webcsd-csp-miniconda3-$(miniconda_installer_version)-$(Build.BuildId)-$(buildosname)'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/webcsd-csp-miniconda3-$(miniconda_installer_version)-$(Build.BuildId)-$(buildosname).$(outputArchiveExtension)'
     archiveType: '$(outputArchiveType)'
 
 - task: ArchiveFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,9 +41,17 @@ steps:
   displayName: 'Create Offline installer'
 
 - task: ArchiveFiles@2
+  displayName: 'Archive minimal miniconda archive'
+  inputs:
+    rootFolderOrFile: '$(System.DefaultWorkingDirectory)/output/minimal-miniconda3-$(miniconda_installer_version)-$(Build.BuildId)-$(buildosname)'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/minimal-miniconda3-$(miniconda_installer_version)-$(Build.BuildId)-$(buildosname).$(outputArchiveExtension)'
+    archiveType: '$(outputArchiveType)'
+
+- task: ArchiveFiles@2
+  displayName: 'Archive miniconda archive'
   inputs:
     rootFolderOrFile: '$(System.DefaultWorkingDirectory)/output/miniconda3-$(miniconda_installer_version)-$(Build.BuildId)-$(buildosname)'
-    archiveFile: '$(Build.ArtifactStagingDirectory)/miniconda3-$(miniconda_installer_version)-$(Build.BuildId)-$(buildosname).$(outputArchiveExtension)' 
+    archiveFile: '$(Build.ArtifactStagingDirectory)/miniconda3-$(miniconda_installer_version)-$(Build.BuildId)-$(buildosname).$(outputArchiveExtension)'
     archiveType: '$(outputArchiveType)'
 
 # Upload artifactory build info
@@ -55,7 +63,7 @@ steps:
       {
         "files": [
           {
-            "pattern": "$(Build.ArtifactStagingDirectory)/miniconda3*",
+            "pattern": "$(Build.ArtifactStagingDirectory)/*miniconda3*",
             "target": "ccdc-3rdparty-python-interpreters"
           }
         ]

--- a/smoke_test.bat
+++ b/smoke_test.bat
@@ -1,2 +1,2 @@
 call "%~1\\Scripts\\activate.bat"
-python smoke_test.py
+python smoke_test.py %2

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1,5 +1,5 @@
 import sys
-minimal = sys.argv[1] == 'minimal'
+full = sys.argv[1] == 'full'
 
 import_ok = True
 
@@ -57,7 +57,13 @@ except:
     print('Cannot import from xgboost')
     import_ok = False
 
-if not minimal:
+try:
+    import docxtpl
+except:
+    print('Cannot import docxtpl')
+    import_ok = False
+
+if full:
     try:
         import matplotlib
         matplotlib.use('Agg')

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1,15 +1,13 @@
+import sys
+minimal = sys.argv[1] == 'minimal'
+
 import_ok = True
+
 print('Testing all imports')
 try:
     from PIL import Image
 except:
     print('Cannot import Image from pillow')
-    import_ok = False
-
-try:
-    import six
-except:
-    print('Cannot import six')
     import_ok = False
 
 try:
@@ -22,14 +20,6 @@ try:
     import numpy
 except:
     print('Cannot import numpy')
-    import_ok = False
-
-try:
-    import matplotlib
-    matplotlib.use('Agg')
-    import matplotlib.pyplot as plot
-except Exception as e:
-    print(f'Cannot import matplotlib: {e}')
     import_ok = False
 
 try:
@@ -67,17 +57,26 @@ except:
     print('Cannot import from xgboost')
     import_ok = False
 
-try:
-    from scipy import misc
-except:
-    print('Cannot import from scipy')
-    import_ok = False
+if not minimal:
+    try:
+        import matplotlib
+        matplotlib.use('Agg')
+        import matplotlib.pyplot as plot
+    except Exception as e:
+        print(f'Cannot import matplotlib: {e}')
+        import_ok = False
 
-try:
-    from tensorflow.keras.models import load_model
-except:
-    print('Cannot import from tensorflow')
-    import_ok = False
+    try:
+        from scipy import misc
+    except:
+        print('Cannot import from scipy')
+        import_ok = False
+
+    try:
+        from tensorflow.keras.models import load_model
+    except:
+        print('Cannot import from tensorflow')
+        import_ok = False
 
 if not import_ok:
     import sys

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 source $1/bin/activate ''
-python3 smoke_test.py
+python3 smoke_test.py $2


### PR DESCRIPTION
Build two offline installers - one of them the usual one for the CSDS installer.

The other "minimal" one includes dependencies just for csd-python-api (and not any of the Mercury scripts). This is used the webcsd_csp installer.