### PR TITLE
New conda dependency for webcsdcsp miniconda (PYAPI-2926)

### DIFF
--- a/create_offline_installer.py
+++ b/create_offline_installer.py
@@ -27,7 +27,7 @@ def required_offline_conda_packages(prefix, extra_conda_packages):
     api_pkgs = [
         'pillow<9.0',
         'lxml==4.6.3',
-        'numpy==1.21.3', # also used in mercury scripts
+        'numpy==1.21.6', # also used in mercury scripts
         'pytest',
         'pandas==1.2.5', # also used in mercury scripts
         'xgboost==1.5.0', # equivalent to py-xgboost, but more used
@@ -467,6 +467,7 @@ conda install -y --channel "$INSTALLER_DIR/conda_offline_channel" --offline --ov
 shift
 while test $# -gt 1
 do
+    echo "CCDC Miniconda installer: Installing $2"
     conda install -y --channel "$INSTALLER_DIR/$1_conda_channel" --offline --override-channels -q $2
     [ $? -eq 0 ] || exit $?; # exit if non-zero return code
     shift

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1,5 +1,5 @@
 import sys
-full = sys.argv[1] == 'full'
+prefix = sys.argv[1]
 
 import_ok = True
 
@@ -63,7 +63,7 @@ except:
     print('Cannot import docxtpl')
     import_ok = False
 
-if full:
+if prefix == 'full':
     try:
         import matplotlib
         matplotlib.use('Agg')


### PR DESCRIPTION
Increase the numpy dependency version from 1.21.3 to 1.21.6. This is because conda now adds the 1.21.6 requirement when building the csd-python-api conda package.